### PR TITLE
fix for empty output

### DIFF
--- a/src/Http/Controllers/ComposerViewerController.php
+++ b/src/Http/Controllers/ComposerViewerController.php
@@ -19,7 +19,8 @@ class ComposerViewerController extends Controller
     {
         $which_composer = config('admin.extensions.composer-viewer.which-composer', '/usr/local/bin/composer');
         try {
-            $command = 'cd ' . base_path() . ' && ' . $which_composer . ' show --latest --format=json';
+            $command = 'export COMPOSER_HOME="$HOME/.config/composer"; ';
+            $command .= 'cd ' . base_path() . ' && ' . $which_composer . ' show --latest --format=json';
             exec($command, $output);
             $packages = json_decode(implode('', $output), true)['installed'];
 


### PR DESCRIPTION
noticed this in my apache error logs:
[RuntimeException]
  The HOME or COMPOSER_HOME environment variable must be set for composer to run correctly